### PR TITLE
iOS Build Error

### DIFF
--- a/react-native-kakao-ad.podspec
+++ b/react-native-kakao-ad.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'
-  s.dependency 'KakaoAdSDK'
+  s.dependency 'KakaoAdSDK', '0.6.0'
 end
 


### PR DESCRIPTION
KakaoAdSDK의 버전이 오름에 따라 빌드가 안되는 버그 0.6.0으로 KakaoAdSDK 설치해야 합니다.